### PR TITLE
add special slot '__esModule'

### DIFF
--- a/src/lib/__tests__/moduleMocker-test.js
+++ b/src/lib/__tests__/moduleMocker-test.js
@@ -99,5 +99,21 @@ describe('moduleMocker', function() {
 
       expect(instanceFooMock.toString.mock).not.toBeUndefined();
     });
+
+    it('does not mock __esModule special property (babel6)', function() {
+      var ClassFoo = function() {};
+
+      var fooModule = {
+        __esModule: true,
+        default: ClassFoo,
+      };
+
+      var fooModuleMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(fooModule)
+      );
+
+      expect(fooModuleMock.__esModule).toEqual(fooModule.__esModule);
+    });
+
   });
 });

--- a/src/lib/moduleMocker.js
+++ b/src/lib/moduleMocker.js
@@ -287,6 +287,12 @@ function generateMock(metadata, callbacks, refs) {
 
   getSlots(metadata.members).forEach(slot => {
     const slotMetadata = metadata.members[slot];
+    // special slot used by babel 6
+    if (slot === '__esModule') {
+      mock[slot] =  metadata.members[slot];
+      return;
+    }
+
     if (slotMetadata.ref != null) {
       callbacks.push(() => mock[slot] = refs[slotMetadata.ref]);
     } else {
@@ -349,6 +355,13 @@ function getMetadata(component, _refs) {
   if (type !== 'array') {
     if (type !== 'undefined') {
       getSlots(component).forEach(slot => {
+        // special slot used by babel 6
+        if (slot === '__esModule')  {
+          members = members || {};
+          members[slot] = component[slot];
+          return;
+        }
+
         if (
           slot.charAt(0) === '_' ||
           (


### PR DESCRIPTION
allow mocking modules using babel 6

`babel 6`,  when passing from `es6` modules to commonJs, adds a property call `__esModule`, later when the module is imported  (`es6 import`), babel will transform it:

```javascript
import dependencyModule from './dependencyModule'
```
becomes this ->

```javascript

var _dependencyModule = require('./dependencyModule');

var _dependencyModule2 = _interopRequireDefault(_dependencyModule);
function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

```
(what the module will actually use is _dependencyModule2)

so  jest will mock `require('./dependencyModule')`, and when it mocks it, it destroys the `__esModule` property, without this property  we will get this as a mock `{ default: dependencyModuleMock }` instead of the desired  `dependencyModuleMock`